### PR TITLE
Allow document to use stream id more than once

### DIFF
--- a/src/main/java/org/bitfunnel/reproducibility/ChunkDocument.java
+++ b/src/main/java/org/bitfunnel/reproducibility/ChunkDocument.java
@@ -132,12 +132,6 @@ public class ChunkDocument implements Document {
                 throw new IOException("ChunkDocument.tryParseStream(): expected zero after stream id.");
             }
 
-            // Verify that we haven't seen this stream id before.
-            // TODO: Consider changing chunk format to disallow multiple instances of a stream.
-            if (streams[id] != null) {
-                throw new IOException("ChunkDocument.tryParseStream(): encountered duplicate stream id.");
-            }
-
             // Append the contents of this stream to the end of the buffer.
             // Scan past bytes that match "(Term End)*" End where Term is a sequence of non-zero utf-8 bytes
             // and End is the byte '\0'.

--- a/src/main/java/org/bitfunnel/reproducibility/IndexExporter.java
+++ b/src/main/java/org/bitfunnel/reproducibility/IndexExporter.java
@@ -40,8 +40,10 @@ public class IndexExporter {
     // TODO: Add javadoc
     public IndexExporter(String basename) throws IllegalAccessException, InvocationTargetException, NoSuchMethodException, IOException, InstantiationException, URISyntaxException, ConfigurationException, ClassNotFoundException {
         // Load and configure the index.
-        text = Index.getInstance( basename + "-text?inmemory=1", true, true );
-        title = Index.getInstance( basename + "-title?inmemory=1", true, true );
+        text = Index.getInstance( basename + "-text", true, true );
+        title = Index.getInstance( basename + "-title", true, true );
+//      text = Index.getInstance( basename + "-text?inmemory=1", true, true );
+//      title = Index.getInstance( basename + "-title?inmemory=1", true, true );
 
         indexMap = new Object2ReferenceOpenHashMap<String,Index>(
             new String[] { "text", "title" }, new Index[] { text, title } );


### PR DESCRIPTION
The new `BtiFunnel filter -write annotate` option injects a shard term into its own stream, reusing the id for the main stream. This means two streams in a document might have the same id. Currently, however, the MG4J workbench disallows this when creating the MG4J index from BitFunnel chunks.

The attached commit removes this restriction.