### PR TITLE
Support streams that include multiple segments

### DIFF
--- a/src/main/java/org/bitfunnel/reproducibility/ChunkDocument.java
+++ b/src/main/java/org/bitfunnel/reproducibility/ChunkDocument.java
@@ -31,7 +31,7 @@ public class ChunkDocument implements Document {
      * StreamSegment represents a contiguous collection of terms for a
      * document stream (or field in mg4j parlance) with backing utf-8 data
      * in buffer[offset..offset + length - 1].
-     * A single stream may be modeled as the concatendation of multiple segments.
+     * A single stream may be modeled as the concatenation of multiple segments.
      */
     private class StreamSegment {
         public StreamSegment(int offset, int length) {
@@ -46,7 +46,7 @@ public class ChunkDocument implements Document {
          *   [offset, offset + length - 1]
          * When the trim parameter is true, the stream corresponds to buffer
          * index values in the range
-         *   [offset, offset + length - 1)
+         *   [offset, offset + length - 2)
          * The trim functionality is provided to exclude EOF bytes during
          * stream concatenation.
          */


### PR DESCRIPTION
It is possible for a document in a BitFunnel chunk to include multiple "segments" for the same stream id. For example, the `BitFunnel filter -writer annotate` option injects a shard term as a second segment of the text stream '00'.

This commit enables a chunk document to return a Reader that treats multiple segments for a given stream id as if they were a single concatenated InputStream.